### PR TITLE
chore: remove artifacts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,9 +3,7 @@ node_modules
 #Hardhat files
 cache
 artifacts/*
-!artifacts/contracts
-artifacts/contracts/*/*.dbg.json
-artifacts/contracts/test
+artifacts/contracts
 
 test
 abis


### PR DESCRIPTION
BREAKING CHANGE: This change removes the ABIs from /artifacts/contracts, instead, import contracts from /deployments